### PR TITLE
No need for blocknotify

### DIFF
--- a/dashd.conf
+++ b/dashd.conf
@@ -4,4 +4,3 @@ printtoconsole=1
 statsenabled=1
 statshost=graphite
 statsport=8125
-blocknotify=dash-cli getmininginfo && sleep 30 && dash-cli gettxoutsetinfo


### PR DESCRIPTION
In Dash we use `-statsperiod` (default 60, in seconds) to update corresponding stats periodically instead of relying on rpc.