### PR TITLE
Expose port 8125 for statsd service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     image: graphiteapp/graphite-statsd
     restart: always
     ports:
+      - 8125:8125
       - 3000:80
     volumes:
       - "./storage-schemas.conf:/opt/graphite/conf/storage-schemas.conf"


### PR DESCRIPTION
This allows to push stats from the machine it's running on e.g. system metrics.